### PR TITLE
libcameraservice: Don't pass NULL args on setCallbacks call

### DIFF
--- a/services/camera/libcameraservice/CameraFlashlight.cpp
+++ b/services/camera/libcameraservice/CameraFlashlight.cpp
@@ -828,6 +828,18 @@ status_t CameraHardwareInterfaceFlashControl::initializePreviewWindow(
     return device->setPreviewWindow(mSurface);
 }
 
+static void notifyCallback(int32_t, int32_t, int32_t, void*) {
+    /* Empty */
+}
+
+static void dataCallback(int32_t, const sp<IMemory>&, camera_frame_metadata_t*, void*) {
+    /* Empty */
+}
+
+static void dataCallbackTimestamp(nsecs_t, int32_t, const sp<IMemory>&, void*) {
+    /* Empty */
+}
+
 status_t CameraHardwareInterfaceFlashControl::connectCameraDevice(
         const String8& cameraId) {
     sp<CameraHardwareInterface> device =
@@ -841,7 +853,7 @@ status_t CameraHardwareInterfaceFlashControl::connectCameraDevice(
     }
 
     // need to set __get_memory in set_callbacks().
-    device->setCallbacks(NULL, NULL, NULL, NULL);
+    device->setCallbacks(notifyCallback, dataCallback, dataCallbackTimestamp, this);
 
     mParameters = device->getParameters();
 


### PR DESCRIPTION
http://review.cyanogenmod.org/#/c/161808/

*This fixes the torch light for cameras with hal 1 
*This fix works on the htc m7ul
